### PR TITLE
Add initial work towards function evalulation and interpretM handling

### DIFF
--- a/Patrus.md
+++ b/Patrus.md
@@ -1325,7 +1325,11 @@ Gets desguared to:
 
 ## [10 - Functions](https://craftinginterpreters.com/functions.html)
 
+Skipped error handling parts: 10.1.1,
+
 ### [10.1 - Function Calls](https://craftinginterpreters.com/functions.html#function-calls)
+
+Commit ca356a9
 
 ```
 call → primary ( "(" arguments? ")" )* ;
@@ -1370,7 +1374,7 @@ parseProgram "foo(1,2,3)(true)(nil);"
 
 #### [10.1.1 - Maximum argument counts](https://craftinginterpreters.com/functions.html#maximum-argument-counts)
 
---TODO max arg counts error handling
+SKIPPED max arg counts error handling
 
 Skipping this for now until we come back to parser error handling
 
@@ -1394,4 +1398,34 @@ print z;
 
 Type checking occurs after function argument evaluation.
 
-TODO add a spectest for all native functions
+#### [10.1.3 - Call type errors](https://craftinginterpreters.com/functions.html#call-type-errors)
+
+TODO Commit 0636fa
+
+#### [10.1.4 - Checking arity](https://craftinginterpreters.com/functions.html#checking-arity)
+
+TODO Commit 0636fa
+
+### [10.2 - Native Functions](https://craftinginterpreters.com/functionsctions.html#native-fun)
+
+TODO Commit 0636fa
+
+#### [10.2.1 - Telling time](https://craftinginterpreters.com/functions.html#native-functions)
+
+TODO Commit 0636fa
+
+### [10.3 - Function Declarations](https://craftinginterprete.html#function-drs.com/functionseclarations)
+
+TODO Commit d109c0
+
+### [10.4 - Function Objects](https://craftinginterpreters.com/functions.html#function-objects)
+
+Note this presentation order could be redone. It was much easier to add return statements. 1/5/22
+
+TODO
+
+Commits 711631
+
+### [10.5 - Return Statements](https://craftinginterpreters.com/functions.html#return-statements)
+
+TODO Commits fc1820, 1979f, 1efcdd

--- a/src/Patrus/Environment.hs
+++ b/src/Patrus/Environment.hs
@@ -34,9 +34,6 @@ pushFreshEnv parentEnv = Env M.empty parentEnv
 popEnv :: Environment -> Environment
 popEnv (Env _ p) = p
 
-withFreshEnv :: EvalM a -> EvalM ()
-withFreshEnv f = modifyEnv (pushFreshEnv) >> f >> modifyEnv (popEnv)
-
 pushFuncEnv :: [(Identifier, Expr)] -> Environment -> Environment
 pushFuncEnv bindings env = Env (M.fromList bindings) env
 

--- a/src/Patrus/Eval.hs
+++ b/src/Patrus/Eval.hs
@@ -211,3 +211,5 @@ interpretM ((ReturnStatement Nothing): xs) = return (Lit Nil, xs)
 interpretM ((ReturnStatement (Just e)): xs) = do
     e' <- eval e
     return (e', xs)
+
+interpretM ((FunStatement name args body) : xs) = trace ("TODO function declaration 10.4 10.4.1 ") undefined

--- a/src/Patrus/Eval.hs
+++ b/src/Patrus/Eval.hs
@@ -212,4 +212,7 @@ interpretM ((ReturnStatement (Just e)): xs) = do
     e' <- eval e
     return (e', xs)
 
-interpretM ((FunStatement name args body) : xs) = trace ("TODO function declaration 10.4 10.4.1 ") undefined
+interpretM ((FunStatement name args body) : xs) = do
+    let e = Func $ Function args body
+    modifyEnv (insertEnv name e)
+    interpretM xs

--- a/src/Patrus/Eval.hs
+++ b/src/Patrus/Eval.hs
@@ -51,7 +51,7 @@ eval (Call callee args) = do
         e@(Func (Function params body)) -> do
             callTyCheck callee' --Maybe hoist this to case so we can split callee into pieces
             arityCheck params args'
-            let bindings = undefined --TODO zip params and args
+            let bindings = undefined --TODO zip params and args section 10.4
             (retVal, _) <- withFuncEnv bindings $ interpretM [body]
             return retVal
 

--- a/src/Patrus/Eval.hs
+++ b/src/Patrus/Eval.hs
@@ -206,3 +206,8 @@ interpretM w@((WhileStatement conde body):xs) = do
     if literalTruth e
     then interpretM [body] >> interpretM w
     else interpretM xs
+
+interpretM ((ReturnStatement Nothing): xs) = return (Lit Nil, xs)
+interpretM ((ReturnStatement (Just e)): xs) = do
+    e' <- eval e
+    return (e', xs)

--- a/src/Patrus/Interpret.hs
+++ b/src/Patrus/Interpret.hs
@@ -14,53 +14,6 @@ import qualified Data.Map.Strict as M
 runEvalM :: EvalM Expr -> Environment -> IO (Expr, Environment)
 runEvalM x = runStateT (runEval x)
 
-interpretM :: Program -> EvalM Program
-interpretM [] = return []
-interpretM ((PrintStatement e): xs) = do
-    e' <- eval e
-    liftIO $ print $ "PRINT: " <> show e'
-    interpretM xs
-
-interpretM ((DumpStatement) : xs) = do
-    env <- get
-    liftIO $ print $ "DUMP: " <> show env
-    interpretM xs
-
-interpretM ((ExprStatement e) : xs) = do
-    _ <- eval e
-    interpretM xs
-
-interpretM ((VarDeclaration i Nothing) : xs) = do
-    modifyEnv $ insertEnv i (Lit Nil)
-    interpretM xs
-
-interpretM (VarDeclaration i (Just e) : xs) = do
-    e' <- eval e
-    modifyEnv (insertEnv i e')
-    interpretM xs
-
-interpretM ((BlockStatement bs):xs) = do
-    withFreshEnv (interpretM bs)
-    interpretM xs
-
-interpretM ((IfStatement conde trueBranch falseBranch): xs) = do
-    e <- eval conde
-
-    if literalTruth e
-    then interpretM [trueBranch]
-    else case falseBranch of
-        Just fb -> interpretM [fb]
-        Nothing -> pure []
-
-    interpretM xs
-
-interpretM w@((WhileStatement conde body):xs) = do
-    e <- eval conde
-
-    if literalTruth e
-    then interpretM [body] >> interpretM w
-    else interpretM xs
-
 baseGlobalEnv = Env baseScope EmptyEnv
     where baseScope = M.fromList [clock]
           clock = ("clock", NativeFunc Clock []) --impl in eval...
@@ -68,5 +21,10 @@ baseGlobalEnv = Env baseScope EmptyEnv
 interpretProgram :: Program -> IO Environment
 interpretProgram p = execStateT (runEval $ interpretM p) baseGlobalEnv
 
-runProgram :: Program -> IO (Program, Environment)
+-- ((Return value, remainder of the program where it was returned), Enviornment)
+-- interpretM and eval have now become intertwined.
+-- Return statements will give back an expression (to be used by Eval)
+-- Otherwise Unit is returned.
+-- TODO think about this some more... 02:34 01-Jan-22
+runProgram :: Program -> IO ((Expr, Program), Environment)
 runProgram p = runStateT (runEval $ interpretM p) baseGlobalEnv

--- a/src/Patrus/Parser.y
+++ b/src/Patrus/Parser.y
@@ -141,6 +141,11 @@ SimpleStmt : ExprStatement  { $1 }
            | PrintStatement { $1 }
            | Block          { $1 }
            | DumpStatement  { $1 }
+           | ReturnStatement { $1 }
+
+ReturnStatement :: { Statement }
+ReturnStatement : RETURN SEMICOLON { ReturnStatement Nothing }
+                | RETURN Expr SEMICOLON { ReturnStatement (Just $2) }
 
 Block : LEFT_BRACE Declarations RIGHT_BRACE { BlockStatement (reverse $2) }
 

--- a/src/Patrus/Types.hs
+++ b/src/Patrus/Types.hs
@@ -19,6 +19,7 @@ data Statement = ExprStatement Expr
                | IfStatement Expr Statement (Maybe Statement)
                | WhileStatement Expr Statement
                | DumpStatement
+               | ReturnStatement (Maybe Expr)
                deriving (Show, Eq)
 
 data ComparrisonOp = EQ | NEQ | LT | LTE | GT | GTE

--- a/src/Patrus/Types.hs
+++ b/src/Patrus/Types.hs
@@ -44,17 +44,20 @@ data Expr = BOp BinOp Expr Expr
           | Group Expr
           | Var Identifier
           | Assignment Identifier Expr
+          | Func Function
           | Call Expr [Expr]
-          | Func {
-                parameters :: [Identifier] --TODO
-               ,body :: Statement
-          }
-          | NativeFunc {
+                    | NativeFunc {
                 nativeFuncTag :: NativeTag
-               ,parameters :: [Identifier]
+               ,callparameters :: [Identifier]
           }
           | Class --TODO
+          | Unit --TODO remove after we figure out return statements
             deriving (Show, Eq)
+
+data Function = Function {
+                fnparameters :: [Identifier]
+               ,body :: Statement
+          } deriving (Show, Eq)
 
 --IO() can't have an EQ instance so dispatching on this tag will be less of a hassle for now
 --Tag for native function

--- a/test/Patrus/ParserSpec.hs
+++ b/test/Patrus/ParserSpec.hs
@@ -26,3 +26,5 @@ spec = do
                                                                                 [Lit Nil])]
         it "successfully parses function declaration" $ do
             parseProgram "fun add(x,y) { x + y; }" `shouldBe` [FunStatement "add" ["x","y"] (BlockStatement [ExprStatement (BOp Plus (Var "x") (Var "y"))])] --TODO switch to return statement after 10.5
+        it "successfully parses return statements" $ do
+            parseProgram "return 5;" `shouldBe` [ReturnStatement (Just (Lit (NumberLit 5.0)))]

--- a/test/Patrus/ParserSpec.hs
+++ b/test/Patrus/ParserSpec.hs
@@ -25,6 +25,6 @@ spec = do
 
                                                                                 [Lit Nil])]
         it "successfully parses function declaration" $ do
-            parseProgram "fun add(x,y) { x + y; }" `shouldBe` [FunStatement "add" ["x","y"] (BlockStatement [ExprStatement (BOp Plus (Var "x") (Var "y"))])] --TODO switch to return statement after 10.5
+            parseProgram "fun add(x,y) { return x + y; }" `shouldBe` [FunStatement "add" ["x","y"] (BlockStatement [ReturnStatement (Just (BOp Plus (Var "x") (Var "y")))])] --TODO switch to return statement after 10.5
         it "successfully parses return statements" $ do
             parseProgram "return 5;" `shouldBe` [ReturnStatement (Just (Lit (NumberLit 5.0)))]


### PR DESCRIPTION
Moves interpretM into Eval.hs to avoid circular dependency.